### PR TITLE
EpgTimerSrv.iniに空行がある時例外が出ていたので修正

### DIFF
--- a/EpgTimer/EpgTimer/Common/SettingClass.cs
+++ b/EpgTimer/EpgTimer/Common/SettingClass.cs
@@ -307,6 +307,9 @@ namespace EpgTimer
                             else if (section.Length > 0)
                             {
                                 string[] list = buff.Split(new char[] { '=' }, 2);
+                                if (list.Length != 2) {
+                                    continue;
+                                }
                                 this[section].addPair(list[0], list[1]);
                             }
                         }


### PR DESCRIPTION
EpgTimerSrv.iniに空行(buff=="")がある時、例外が発生していたので修正をプルリクエスト出させて頂きます
